### PR TITLE
Fix NIC to GPU proximity detection on systems with multiple PCIe domains (candidate-1.70)

### DIFF
--- a/src/client/Topology.hpp
+++ b/src/client/Topology.hpp
@@ -41,16 +41,21 @@ static void PrintNicToGPUTopo(bool outputToCsv)
 
   int numGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
   auto const& ibvDeviceList = GetIbvDeviceList();
-  for (int i = 0; i < ibvDeviceList.size(); i++) {
 
-    std::string closestGpusStr = "";
-    for (int j = 0; j < numGpus; j++) {
-      if (TransferBench::GetClosestNicToGpu(j) == i) {
-        if (closestGpusStr != "") closestGpusStr += ",";
-        closestGpusStr += std::to_string(j);
-      }
+  // Build inverse map: for each NIC, which GPUs list it as closest?
+  std::vector<std::string> closestGpusForNic(ibvDeviceList.size(), "");
+  for (int j = 0; j < numGpus; j++) {
+    std::vector<int> nicsForGpu;
+    TransferBench::GetClosestNicsToGpu(nicsForGpu, j);
+    for (int nicIdx : nicsForGpu) {
+      if (nicIdx < 0 || nicIdx >= (int)closestGpusForNic.size()) continue;
+      if (!closestGpusForNic[nicIdx].empty()) closestGpusForNic[nicIdx] += ",";
+      closestGpusForNic[nicIdx] += std::to_string(j);
     }
+  }
 
+  for (int i = 0; i < ibvDeviceList.size(); i++) {
+    std::string closestGpusStr = closestGpusForNic[i];
     printf(" %-3d | %-11s | %-6s | %-12s | %-4d | %-14s | %-9s | %-20s\n",
            i, ibvDeviceList[i].name.c_str(),
            ibvDeviceList[i].hasActivePort ? "Yes" : "No",
@@ -187,13 +192,23 @@ void DisplaySingleRankTopology(bool outputToCsv)
 
       char pciBusId[20];
       HIP_CALL(hipDeviceGetPCIBusId(pciBusId, 20, i));
-      printf(" %-11s %c %-4d %c %-4d %c %-4d %c %-4d %c %-4d\n",
+      // Space-separated so the field stays a single column when sep is a comma (CSV mode),
+      // matching how the "Closest GPU(s)" column above is emitted
+      std::vector<int> nicsForGpu;
+      TransferBench::GetClosestNicsToGpu(nicsForGpu, i);
+      std::string nicStr;
+      for (int nicIdx : nicsForGpu) {
+        if (!nicStr.empty()) nicStr += ' ';
+        nicStr += std::to_string(nicIdx);
+      }
+      if (nicStr.empty()) nicStr = "-1";
+      printf(" %-11s %c %-4d %c %-4d %c %-4d %c %-4d %c %s\n",
              pciBusId, sep,
              TransferBench::GetNumSubExecutors({EXE_GPU_GFX, i}), sep,
              TransferBench::GetClosestCpuNumaToGpu(i), sep,
              TransferBench::GetNumExecutorSubIndices({EXE_GPU_DMA, i}), sep,
              TransferBench::GetNumExecutorSubIndices({EXE_GPU_GFX, i}), sep,
-             TransferBench::GetClosestNicToGpu(i));
+             nicStr.c_str());
     }
   }
 #endif

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -8115,19 +8115,6 @@ const auto& AmdSmiFabricInfoV1(const T& info)
       for (auto const& ibvDevice : ibvDeviceList)
         ibvAddressList.push_back(ibvDevice.hasActivePort ? ibvDevice.busId : "");
 
-      // Track how many times a device has been assigned as "closest"
-      // This allows distributed work across devices using multiple ports (sharing the same busID)
-      // NOTE: This isn't necessarily optimal, but likely to work in most cases involving multi-port
-      // Counter example:
-      //
-      //  G0 prefers (N0,N1), picks N0
-      //  G1 prefers (N1,N2), picks N1
-      //  G2 prefers N0,      picks N0
-      //
-      //  instead of G0->N1, G1->N2, G2->N0
-
-      std::vector<int> assignedCount(ibvDeviceList.size(), 0);
-
       // Loop over each GPU to find the closest NIC(s) based on PCIe address
       for (int gpuIndex = 0; gpuIndex < numGpus; gpuIndex++) {
         if (gpuAddressList[gpuIndex].empty()) continue;
@@ -8136,16 +8123,9 @@ const auto& AmdSmiFabricInfoV1(const T& info)
         // Find closest NICs
         std::set<int> closestNicIdxs = GetNearestDevicesInTree(hipPciBusId, ibvAddressList);
 
-        // Pick the least-used NIC to assign as closest
-        int closestIdx = -1;
-        for (auto idx : closestNicIdxs) {
-          if (closestIdx == -1 || assignedCount[idx] < assignedCount[closestIdx])
-            closestIdx = idx;
-        }
-
         // The following will only use distance between bus IDs
         // to determine the closest NIC to GPU if the PCIe tree approach fails
-        if (closestIdx < 0) {
+        if (closestNicIdxs.empty()) {
   #ifdef VERBS_DEBUG
           Log("[WARN] Falling back to PCIe bus ID distance to determine proximity\n");
   #endif
@@ -8153,17 +8133,18 @@ const auto& AmdSmiFabricInfoV1(const T& info)
           for (int nicIndex = 0; nicIndex < numNics; nicIndex++) {
             if (ibvDeviceList[nicIndex].busId != "") {
               int distance = GetBusIdDistance(hipPciBusId, ibvDeviceList[nicIndex].busId);
-              if (distance < minDistance && distance >= 0) {
+              if (distance >= 0 && distance < minDistance) {
                 minDistance = distance;
-                closestIdx = nicIndex;
+                closestNicIdxs.clear();
+                closestNicIdxs.insert(nicIndex);
+              } else if (distance >= 0 && distance == minDistance) {
+                closestNicIdxs.insert(nicIndex);
               }
             }
           }
         }
-        if (closestIdx != -1) {
-          topo.closestNicsToGpu[gpuIndex].push_back(closestIdx);
-          assignedCount[closestIdx]++;
-        }
+        for (auto idx : closestNicIdxs)
+          topo.closestNicsToGpu[gpuIndex].push_back(idx);
       }
 
       // Compute the reverse mapping: closest GPU(s) for each NIC
@@ -8179,26 +8160,20 @@ const auto& AmdSmiFabricInfoV1(const T& info)
         if (closestGpuIdxs.empty()) {
           // Fallback: use bus ID distance
           int minDistance = std::numeric_limits<int>::max();
-          int closestIdx = -1;
-
           for (int gpuIdx = 0; gpuIdx < numGpus; gpuIdx++) {
             if (gpuAddressList[gpuIdx].empty()) continue;
-
             int distance = GetBusIdDistance(ibvDeviceList[nicIndex].busId, gpuAddressList[gpuIdx]);
             if (distance >= 0 && distance < minDistance) {
               minDistance = distance;
-              closestIdx = gpuIdx;
+              closestGpuIdxs.clear();
+              closestGpuIdxs.insert(gpuIdx);
+            } else if (distance >= 0 && distance == minDistance) {
+              closestGpuIdxs.insert(gpuIdx);
             }
           }
-
-          if (closestIdx != -1) {
-            topo.closestGpusToNic[nicIndex].push_back(closestIdx);
-          }
-        } else {
-          // Store all GPUs that are equally close
-          for (int idx : closestGpuIdxs) {
-            topo.closestGpusToNic[nicIndex].push_back(idx);
-          }
+        }
+        for (int idx : closestGpuIdxs) {
+          topo.closestGpusToNic[nicIndex].push_back(idx);
         }
       }
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3479,8 +3479,11 @@ const auto& AmdSmiFabricInfoV1(const T& info)
     return -1;
   }
 
-  // Function to extract the bus number from a PCIe address (domain:bus:device.function)
-  static int ExtractBusNumber(std::string const& pcieAddress)
+  // Function to extract the domain number from a PCIe address (domain:bus:device.function)
+  // All four fields are read (not just the domain) so that an address with too few fields, or
+  // with a non-hex field, is rejected.  The separator characters themselves are consumed but
+  // not checked, so this is a well-formedness guard rather than strict format validation
+  static int ExtractDomain(std::string const& pcieAddress)
   {
     int domain, bus, device, function;
     char delimiter;
@@ -3493,16 +3496,31 @@ const auto& AmdSmiFabricInfoV1(const T& info)
 #endif
       return -1;
     }
-    return bus;
+    return domain;
   }
 
-  // Function to compute the distance between two bus IDs
-  static int GetBusIdDistance(std::string const& pcieAddress1,
-                              std::string const& pcieAddress2)
+  // Computes a proximity distance between two PCIe addresses.  Used as a secondary
+  // tiebreaker when candidates share the same LCA depth in the PCIe tree, and as the
+  // sole metric in the fallback path when the PCIe tree yields no match at all.
+  // Returns -1 if either address cannot be parsed.
+  //
+  // Same domain (0): devices in one PCIe domain share a root complex, so the LCA tree
+  // already captures their structural proximity.  Bus numbers are firmware-assigned and
+  // do not reliably track physical closeness, so they are deliberately NOT used to
+  // discriminate within a domain -- doing so would break ties between NICs that are
+  // genuinely equidistant from a GPU (e.g. two NICs hanging off the same root complex
+  // at different bus numbers), which is exactly the case this metric must preserve.
+  //
+  // Cross domain (|delta domain|): any non-zero value ranks behind every same-domain
+  // candidate.  The magnitude only provides a deterministic ordering among cross-domain
+  // candidates; it carries no physical meaning.
+  static int GetDomainDistance(std::string const& pcieAddress1,
+                               std::string const& pcieAddress2)
   {
-    int bus1 = ExtractBusNumber(pcieAddress1);
-    int bus2 = ExtractBusNumber(pcieAddress2);
-    return (bus1 < 0 || bus2 < 0) ? -1 : std::abs(bus1 - bus2);
+    int domain1 = ExtractDomain(pcieAddress1);
+    int domain2 = ExtractDomain(pcieAddress2);
+    if (domain1 < 0 || domain2 < 0) return -1;
+    return std::abs(domain1 - domain2);
   }
 
   // Given a target busID and a set of candidate devices, returns a set of indices
@@ -3522,11 +3540,15 @@ const auto& AmdSmiFabricInfoV1(const T& info)
       if (!lca) continue;
 
       int depth = GetLcaDepth(lca->address, GetPCIeTreeRoot());
-      int currDistance = GetBusIdDistance(targetBusId, candidateBusId);
+      int currDistance = GetDomainDistance(targetBusId, candidateBusId);
 
-      // When more than one LCA match is found, choose the one with smallest busId difference
-      // NOTE: currDistance could be -1, which signals problem with parsing, however still
-      //       remains a valid "closest" candidate, so is included
+      // A candidate whose address could not be parsed (-1) remains eligible, but treat its
+      // distance as the largest possible so it can never outrank a candidate whose distance
+      // is actually known.  It can still be selected when nothing else matches at this depth,
+      // and still ties with other unparseable candidates.
+      if (currDistance < 0) currDistance = std::numeric_limits<int>::max();
+
+      // When more than one LCA match is found, choose the one with smallest domain difference
       if (depth > maxDepth || (depth == maxDepth && depth >= 0 && currDistance < minDistance)) {
         maxDepth = depth;
         matches.clear();
@@ -8123,16 +8145,19 @@ const auto& AmdSmiFabricInfoV1(const T& info)
         // Find closest NICs
         std::set<int> closestNicIdxs = GetNearestDevicesInTree(hipPciBusId, ibvAddressList);
 
-        // The following will only use distance between bus IDs
+        // The following will only use distance between PCIe domains
         // to determine the closest NIC to GPU if the PCIe tree approach fails
         if (closestNicIdxs.empty()) {
   #ifdef VERBS_DEBUG
-          Log("[WARN] Falling back to PCIe bus ID distance to determine proximity\n");
+          Log("[WARN] Falling back to PCIe domain distance to determine proximity\n");
   #endif
           int minDistance = std::numeric_limits<int>::max();
           for (int nicIndex = 0; nicIndex < numNics; nicIndex++) {
-            if (ibvDeviceList[nicIndex].busId != "") {
-              int distance = GetBusIdDistance(hipPciBusId, ibvDeviceList[nicIndex].busId);
+            // Use ibvAddressList rather than the raw device list: it is already blanked out
+            // for NICs without an active port, so this stays consistent with the tree path
+            // above and never maps a GPU to a NIC that cannot execute a Transfer
+            if (ibvAddressList[nicIndex] != "") {
+              int distance = GetDomainDistance(hipPciBusId, ibvAddressList[nicIndex]);
               if (distance >= 0 && distance < minDistance) {
                 minDistance = distance;
                 closestNicIdxs.clear();
@@ -8158,11 +8183,11 @@ const auto& AmdSmiFabricInfoV1(const T& info)
         std::set<int> closestGpuIdxs = GetNearestDevicesInTree(ibvDeviceList[nicIndex].busId, gpuAddressList);
 
         if (closestGpuIdxs.empty()) {
-          // Fallback: use bus ID distance
+          // Fallback: use PCIe domain distance
           int minDistance = std::numeric_limits<int>::max();
           for (int gpuIdx = 0; gpuIdx < numGpus; gpuIdx++) {
             if (gpuAddressList[gpuIdx].empty()) continue;
-            int distance = GetBusIdDistance(ibvDeviceList[nicIndex].busId, gpuAddressList[gpuIdx]);
+            int distance = GetDomainDistance(ibvDeviceList[nicIndex].busId, gpuAddressList[gpuIdx]);
             if (distance >= 0 && distance < minDistance) {
               minDistance = distance;
               closestGpuIdxs.clear();


### PR DESCRIPTION
Candidate-1.70 counterpart of #352 (same fix, rebased onto `candidate-1.70` instead of `develop`).

## Motivation

On systems where each GPU sits in its own PCIe domain, TransferBench picked the wrong NIC as closest, thus every GPU mapped to a single front-end NIC that is not wired to any GPU, while the back-end NICs actually adjacent to each GPU mapped to nothing. The mapping decides which NIC a GPU uses for RDMA transfers (`NIC_NEAREST` executor, `nic_rings` preset). With incorrect mapping it would mean benchmarking using a NIC that is not attached to that GPU's root complex, producing misleading numbers. The causes are:

1. The proximity metric compared raw bus numbers. Bus numbers repeat across domains, so devices in different domains looked "close" purely because their bus numbers were numerically near.
2. When several NICs were equally close, only one was recorded, chosen by a round-robin counter, so a GPU with two adjacent NICs only ever reported one.

This PR fixes the topology detection so it works correctly on systems with multiple PCIe domains and multiple NICs per GPU (verified on a 4-GPU, 8 BE + 1 FE, or 2 BE NICs per GPU).

## Technical Details

1. **Use PCIe domain, not bus number, for the distance metric.** `ExtractBusNumber` became `ExtractDomain`, and `GetBusIdDistance` became `GetDomainDistance`.

   The distance between two devices is now computed as follows:
   - If both devices sit in the same PCIe domain, the distance is 0. Within a single domain, the PCIe tree search already tells us how the two devices are related, so no extra tie-break is needed.
   - If the two devices sit in different domains, the distance is the difference between their domain numbers. That value is always at least 1, so a device in a different domain always ranks behind every device in the same domain.

   Bus numbers are no longer used to compare devices within a domain. Firmware assigns them, and they do not reliably indicate which device is physically closer. Using them would also separate NICs that are genuinely the same distance from a GPU, and reporting those ties is the point of this fix.

   An unparseable address (-1) is clamped to `INT_MAX` rather than compared directly, so it remains eligible as a last resort but can never incorrectly outrank a candidate with a known distance.

2. **Record all equally-close NICs/GPUs.** Replaces the `assignedCount` round-robin, which picked one NIC per GPU even when several were tied. Both directions now keep the full tie set, matching how `GetClosestNicsToGpu()` was already shaped.

   Trade-off: the removed round-robin was intended to spread multi-port NICs (ports sharing one busId) across GPUs. With ties recorded, `nic_rings` now uses *all* tied ports, better, but a bare `NIC_NEAREST` resolves slot 0 for every GPU rather than spreading. Use the explicit `N<gpu>.<slot>` form to select a specific port.

3. **Update the CLI topology display.** The display called the scalar `GetClosestNicToGpu()`, so it would have shown one NIC even after (2). Switched to the vector API. The NIC list is space-separated so the field stays a single column under `OUTPUT_TO_CSV=1`, where the separator is a comma.

   Both fallback paths (GPU->NIC and NIC->GPU) now read from `ibvAddressList` rather than the raw device list, so a NIC with a down port is never recorded as "closest" -- `NicIsActive()` would otherwise abort the Transfer with `ERR_FATAL` rather than falling back.

## Test Plan

Built and ran on a `candidate-1.70` base (`92b0df7`) on a gfx1250 rack node: 4 GPUs, 8 BE NICs + 1 FE NIC, 2 NICs wired via PCIe per GPU, each GPU in its own PCIe domain, ROCm 7.15.0.

## Test Result

Currently with candidate-1.70 or develop HEAD:
```
 NIC | Device Name | Active | PCIe Bus ID  | NUMA | Closest GPU(s) | GID Index | GID Descriptor
-----+-------------+--------+--------------+------+----------------+-----------+-------------------
 0   | ionic_0     | Yes    | 0000:04:00.0 | 0    | 0,1,2,3        | 1         | RoCEv2 IPv4-mapped IPv6
 1   | ionic_1     | Yes    | 0001:44:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 2   | ionic_2     | Yes    | 0001:48:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 3   | ionic_3     | Yes    | 0003:44:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 4   | ionic_4     | Yes    | 0003:48:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 5   | ionic_5     | Yes    | 0002:44:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 6   | ionic_6     | Yes    | 0002:48:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 7   | ionic_7     | Yes    | 0004:44:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6
 8   | ionic_8     | Yes    | 0004:48:00.0 | -1   |                | 1         | RoCEv2 IPv4-mapped IPv6

        | gfx1250 | gfx1250 | gfx1250 | gfx1250 |
        | GPU 00 | GPU 01 | GPU 02 | GPU 03 | PCIe Bus ID  | #CUs | NUMA | #DMA | #XCC | NIC
--------+--------+--------+--------+--------+--------------+------+------+------+------+------
 GPU 00 |    N/A | XGMI-1 | XGMI-1 | XGMI-1 | 0001:01:00.0 | 256  | 0    | 16   | 8    | 0
 GPU 01 | XGMI-1 |    N/A | XGMI-1 | XGMI-1 | 0002:01:00.0 | 256  | 0    | 16   | 8    | 0
 GPU 02 | XGMI-1 | XGMI-1 |    N/A | XGMI-1 | 0003:01:00.0 | 256  | 0    | 16   | 8    | 0
 GPU 03 | XGMI-1 | XGMI-1 | XGMI-1 |    N/A | 0004:01:00.0 | 256  | 0    | 16   | 8    | 0
```

With `./TransferBench` (no args):

```
 NIC | Device Name | Active | PCIe Bus ID  | NUMA | Closest GPU(s) | GID Index | GID Descriptor
-----+-------------+--------+--------------+------+----------------+-----------+-------------------
 0   | ionic_0     | Yes    | 0000:04:00.0 | 0    |                | 1         | RoCEv2 IPv4-mapped IPv6
 1   | ionic_1     | Yes    | 0001:44:00.0 | -1   | 0              | 1         | RoCEv2 IPv4-mapped IPv6
 2   | ionic_2     | Yes    | 0001:48:00.0 | -1   | 0              | 1         | RoCEv2 IPv4-mapped IPv6
 3   | ionic_3     | Yes    | 0003:44:00.0 | -1   | 2              | 1         | RoCEv2 IPv4-mapped IPv6
 4   | ionic_4     | Yes    | 0003:48:00.0 | -1   | 2              | 1         | RoCEv2 IPv4-mapped IPv6
 5   | ionic_5     | Yes    | 0002:44:00.0 | -1   | 1              | 1         | RoCEv2 IPv4-mapped IPv6
 6   | ionic_6     | Yes    | 0002:48:00.0 | -1   | 1              | 1         | RoCEv2 IPv4-mapped IPv6
 7   | ionic_7     | Yes    | 0004:44:00.0 | -1   | 3              | 1         | RoCEv2 IPv4-mapped IPv6
 8   | ionic_8     | Yes    | 0004:48:00.0 | -1   | 3              | 1         | RoCEv2 IPv4-mapped IPv6

        | gfx1250 | gfx1250 | gfx1250 | gfx1250 |
        | GPU 00 | GPU 01 | GPU 02 | GPU 03 | PCIe Bus ID  | #CUs | NUMA | #DMA | #XCC | NIC
--------+--------+--------+--------+--------+--------------+------+------+------+------+------
 GPU 00 |    N/A | XGMI-1 | XGMI-1 | XGMI-1 | 0001:01:00.0 | 256  | 0    | 16   | 8    | 1 2
 GPU 01 | XGMI-1 |    N/A | XGMI-1 | XGMI-1 | 0002:01:00.0 | 256  | 0    | 16   | 8    | 5 6
 GPU 02 | XGMI-1 | XGMI-1 |    N/A | XGMI-1 | 0003:01:00.0 | 256  | 0    | 16   | 8    | 3 4
 GPU 03 | XGMI-1 | XGMI-1 | XGMI-1 |    N/A | 0004:01:00.0 | 256  | 0    | 16   | 8    | 7 8
```

Each GPU is now correctly mapped to the NIC(s) in its own PCIe domain (GPU0->1,2, GPU1->5,6, GPU2->3,4, GPU3->7,8), and the front-end NIC (domain `0000`) correctly shows no GPU mapping.

Also see #352 (same fix against `develop`), which was additionally verified against a real link-flap event: a NIC going down/up correctly changed a GPU from a tie to a single mapping and back.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
